### PR TITLE
function columnsCheck(self, col) created #6

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,3 +7,4 @@ v0.1.9, 04.01.2014 -- Fix Issue #14 (https://github.com/luca-dex/pyTSA/issues/14
 v0.1.9, 05.01.2014 -- Fix Issue #8 (https://github.com/luca-dex/pyTSA/issues/8)
 v0.1.10, 08.01.2014 -- Fix Issue #10 (https://github.com/luca-dex/pyTSA/issues/10)
 v0.1.11, 09.01.2014 -- Tight layout
+v0.1.12, 11.01.2014 -- Fix Issue #6 (https://github.com/luca-dex/pyTSA/issues/6)

--- a/pytsa/dataobject.py
+++ b/pytsa/dataobject.py
@@ -556,8 +556,7 @@ class DataObject:
             start = self.__timemin
         if stop is None:
             stop = self.__timemax
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         start = float(start)
         stop = float(stop)
         if len(columns) == 1:
@@ -652,8 +651,7 @@ class DataObject:
             start = self.__timemin
         if stop is None:
             stop = self.__timemax
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         start = float(start)
         stop = float(stop)
         step = float(step)
@@ -746,8 +744,7 @@ class DataObject:
             start = self.__timemin
         if stop is None:
             stop = self.__timemax
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         start = float(start)
         stop = float(stop)
         step = float(step)
@@ -841,8 +838,7 @@ class DataObject:
             start = self.__timemin
         if stop is None:
             stop = self.__timemax
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         start = float(start)
         stop = float(stop)
         step = float(step)
@@ -959,8 +955,7 @@ class DataObject:
         fit boolean (defaul None) : If True fits the histrogram with a gaussian, works if normed
         xkcd boolean (defaul None) : If you want xkcd-style"""
         time = float(time)
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         value = float(time)
         if len(columns) == 1:
             merge = True
@@ -1162,8 +1157,7 @@ class DataObject:
             start = self.__timemin
         if stop is None:
             stop = self.__timemax
-        if columns is None:
-            columns = self.__columns
+        columns = self.columnsCheck(columns)
         step = float(step)
         moments = np.arange(start, stop, step)
         
@@ -1362,6 +1356,17 @@ class DataObject:
                     f.write(str(col))
                     f.write('\t')
                 f.write('\n')
+
+    def columnsCheck(self, col):
+        if col is None:
+            return self.__columns
+        if isinstance(col, str):
+            col = col.split()
+        for c in col:
+            if c not in self.__columns:
+                error = 'Column ' + c + ' not in columns'
+                raise ValueError(error)
+        return col
 
 
 class RedPandaInfo(ts.IsDescription):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name = "pyTSA",
-    version = "0.1.11",
+    version = "0.1.12",
     packages=['pytsa'],
 
     # Project uses reStructuredText, so ensure that the docutils get


### PR DESCRIPTION
Now a new syntax can be used to define the columns. In addition to the current syntax `['x1', 'x2']`, you can now declare with 'x1 x2'.

A ValueError is raised if the name of a column passed is not correct.

fix #6 
